### PR TITLE
No existing task id catch

### DIFF
--- a/clikan.py
+++ b/clikan.py
@@ -167,7 +167,7 @@ def promote(id):
 
     try:
         item = dd['data'].get(int(id))
-        if item == None:
+        if item is None:
             click.echo('No existing task with that id.')
         elif item[0] == 'todo':
             if ('limits' in config and 'wip' in config['limits'] and
@@ -205,7 +205,7 @@ def regress(id):
     config = read_config_yaml()
     dd = read_data(config)
     item = dd['data'].get(int(id))
-    if item == None:
+    if item is None:
         click.echo('No existing task with that id.')
     elif item[0] == 'done':
         click.echo('Regressing task %s to in-progress.' % id)

--- a/clikan.py
+++ b/clikan.py
@@ -167,7 +167,9 @@ def promote(id):
 
     try:
         item = dd['data'].get(int(id))
-        if item[0] == 'todo':
+        if item == None:
+            click.echo('No existing task with that id.')
+        elif item[0] == 'todo':
             if ('limits' in config and 'wip' in config['limits'] and
                     int(config['limits']['wip']) <= len(inprogs)):
                 click.echo(
@@ -203,7 +205,9 @@ def regress(id):
     config = read_config_yaml()
     dd = read_data(config)
     item = dd['data'].get(int(id))
-    if item[0] == 'done':
+    if item == None:
+        click.echo('No existing task with that id.')
+    elif item[0] == 'done':
         click.echo('Regressing task %s to in-progress.' % id)
         dd['data'][int(id)] = ['inprogress', item[1], timestamp(), item[3]]
         write_data(config, dd)


### PR DESCRIPTION
Hi @kitplummer, thanks for developing clikan! This is such a helpful tool, and I use in my everyday workflow! 👍

Are you still accepting pull requests / maintining this? I spotted that trying to promote or regress a non-existing task id throws a python exception (telling you there's a type error since "item[0]" fails when item is None).

This is a small tweak to catch non-existing tasks in the same way you've done when deleting.