### PR TITLE
Adding support for multi-task operations

### DIFF
--- a/clikan.py
+++ b/clikan.py
@@ -129,7 +129,7 @@ def add(tasks):
                     new_id = next(reversed(od)) + 1
                 entry = ['todo', task, timestamp(), timestamp()]
                 dd['data'].update({new_id: entry})
-                click.echo("Creating new task w/ id: %d -> %s" 
+                click.echo("Creating new task w/ id: %d -> %s"
                            % (new_id, task))
 
     write_data(config, dd)

--- a/clikan.py
+++ b/clikan.py
@@ -102,9 +102,9 @@ def configure():
 
 
 @clikan.command()
-@click.argument('task')
-def add(task):
-    """Add a task in todo"""
+@click.argument('tasks', nargs=-1)
+def add(tasks):
+    """Add a tasks in todo"""
     config = read_config_yaml()
     dd = read_data(config)
 
@@ -113,114 +113,118 @@ def add(task):
     else:
         taskname_length = 40
 
-    if len(task) > taskname_length:
-        click.echo('Task must be at most %s chars. Brevity counts.'
-                   % taskname_length)
-    else:
-        todos, inprogs, dones = split_items(config, dd)
-        if ('limits' in config and 'todo' in config['limits'] and
-                int(config['limits']['todo']) <= len(todos)):
-            click.echo('No new todos, limit reached already.')
+    for task in tasks:
+        if len(task) > taskname_length:
+            click.echo('Task must be at most %s chars, Brevity counts: %s'
+                    % (taskname_length, task))
         else:
-            od = collections.OrderedDict(sorted(dd['data'].items()))
-            new_id = 1
-            if bool(od):
-                new_id = next(reversed(od)) + 1
-            entry = ['todo', task, timestamp(), timestamp()]
-            dd['data'].update({new_id: entry})
-            click.echo("Creating new task w/ id: %d -> %s" % (new_id, task))
-            write_data(config, dd)
-            if ('repaint' in config and config['repaint']):
-                display()
+            todos, inprogs, dones = split_items(config, dd)
+            if ('limits' in config and 'todo' in config['limits'] and
+                    int(config['limits']['todo']) <= len(todos)):
+                click.echo('No new todos, limit reached already.')
+            else:
+                od = collections.OrderedDict(sorted(dd['data'].items()))
+                new_id = 1
+                if bool(od):
+                    new_id = next(reversed(od)) + 1
+                entry = ['todo', task, timestamp(), timestamp()]
+                dd['data'].update({new_id: entry})
+                click.echo("Creating new task w/ id: %d -> %s" % (new_id, task))
+    
+    write_data(config, dd)
+    if ('repaint' in config and config['repaint']):
+        display()
 
 
 @clikan.command()
-@click.argument('id')
-def delete(id):
+@click.argument('ids', nargs=-1)
+def delete(ids):
     """Delete task"""
     config = read_config_yaml()
     dd = read_data(config)
-    try:
-        item = dd['data'].get(int(id))
-        if item is None:
-            click.echo('No existing task with that id.')
-        else:
-            item[0] = 'deleted'
-            item[2] = timestamp()
-            dd['deleted'].update({int(id): item})
-            dd['data'].pop(int(id))
-            write_data(config, dd)
-            click.echo('Removed task %d.' % int(id))
-            if ('repaint' in config and config['repaint']):
-                display()
-    except ValueError:
-        click.echo('Invalid task id')
+
+    for id in ids:
+        try:
+            item = dd['data'].get(int(id))
+            if item is None:
+                click.echo('No existing task with that id: %d' % int(id))
+            else:
+                item[0] = 'deleted'
+                item[2] = timestamp()
+                dd['deleted'].update({int(id): item})
+                dd['data'].pop(int(id))
+                click.echo('Removed task %d.' % int(id))
+        except ValueError:
+            click.echo('Invalid task id')
+
+    write_data(config, dd)
+    if ('repaint' in config and config['repaint']):
+        display()
 
 
 @clikan.command()
-@click.argument('id')
-def promote(id):
+@click.argument('ids', nargs=-1)
+def promote(ids):
     """Promote task"""
     config = read_config_yaml()
     dd = read_data(config)
     todos, inprogs, dones = split_items(config, dd)
 
-    try:
-        item = dd['data'].get(int(id))
-        if item is None:
-            click.echo('No existing task with that id.')
-        elif item[0] == 'todo':
-            if ('limits' in config and 'wip' in config['limits'] and
-                    int(config['limits']['wip']) <= len(inprogs)):
-                click.echo(
-                    'Can not promote, in-progress limit of %s reached.'
-                    % config['limits']['wip']
-                )
+    for id in ids:
+        try:
+            item = dd['data'].get(int(id))
+            if item is None:
+                click.echo('No existing task with that id: %s' % id)
+            elif item[0] == 'todo':
+                if ('limits' in config and 'wip' in config['limits'] and
+                        int(config['limits']['wip']) <= len(inprogs)):
+                    click.echo(
+                        'Can not promote, in-progress limit of %s reached.'
+                        % config['limits']['wip']
+                    )
+                else:
+                    click.echo('Promoting task %s to in-progress.' % id)
+                    dd['data'][int(id)] = [
+                        'inprogress',
+                        item[1], timestamp(),
+                        item[3]
+                    ]
+            elif item[0] == 'inprogress':
+                click.echo('Promoting task %s to done.' % id)
+                dd['data'][int(id)] = ['done', item[1], timestamp(), item[3]]
             else:
-                click.echo('Promoting task %s to in-progress.' % id)
-                dd['data'][int(id)] = [
-                    'inprogress',
-                    item[1], timestamp(),
-                    item[3]
-                ]
-                write_data(config, dd)
-                if ('repaint' in config and config['repaint']):
-                    display()
-        elif item[0] == 'inprogress':
-            click.echo('Promoting task %s to done.' % id)
-            dd['data'][int(id)] = ['done', item[1], timestamp(), item[3]]
-            write_data(config, dd)
-            if ('repaint' in config and config['repaint']):
-                display()
-        else:
-            click.echo('Can not promote %s, already done.' % id)
-    except ValueError:
-        click.echo('Invalid task id')
+                click.echo('Can not promote %s, already done.' % id)
+        except ValueError:
+            click.echo('Invalid task id')
+
+    write_data(config, dd)
+    if ('repaint' in config and config['repaint']):
+        display()
 
 
 @clikan.command()
-@click.argument('id')
-def regress(id):
+@click.argument('id', nargs=-1)
+def regress(ids):
     """Regress task"""
     config = read_config_yaml()
     dd = read_data(config)
-    item = dd['data'].get(int(id))
-    if item is None:
-        click.echo('No existing task with that id.')
-    elif item[0] == 'done':
-        click.echo('Regressing task %s to in-progress.' % id)
-        dd['data'][int(id)] = ['inprogress', item[1], timestamp(), item[3]]
-        write_data(config, dd)
-        if ('repaint' in config and config['repaint']):
-            display()
-    elif item[0] == 'inprogress':
-        click.echo('Regressing task %s to todo.' % id)
-        dd['data'][int(id)] = ['todo', item[1], timestamp(), item[3]]
-        write_data(config, dd)
-        if ('repaint' in config and config['repaint']):
-            display()
-    else:
-        click.echo('Already in todo, can not regress %s' % id)
+
+    for id in ids:
+        item = dd['data'].get(int(id))
+        if item is None:
+            click.echo('No existing task with id: %s' % id)
+        elif item[0] == 'done':
+            click.echo('Regressing task %s to in-progress.' % id)
+            dd['data'][int(id)] = ['inprogress', item[1], timestamp(), item[3]]
+        elif item[0] == 'inprogress':
+            click.echo('Regressing task %s to todo.' % id)
+            dd['data'][int(id)] = ['todo', item[1], timestamp(), item[3]]
+        else:
+            click.echo('Already in todo, can not regress %s' % id)
+
+    write_data(config, dd)
+    if ('repaint' in config and config['repaint']):
+        display()
 
 
 # Use a non-Click function to allow for repaint to work.

--- a/clikan.py
+++ b/clikan.py
@@ -116,7 +116,7 @@ def add(tasks):
     for task in tasks:
         if len(task) > taskname_length:
             click.echo('Task must be at most %s chars, Brevity counts: %s'
-                    % (taskname_length, task))
+                       % (taskname_length, task))
         else:
             todos, inprogs, dones = split_items(config, dd)
             if ('limits' in config and 'todo' in config['limits'] and
@@ -129,8 +129,9 @@ def add(tasks):
                     new_id = next(reversed(od)) + 1
                 entry = ['todo', task, timestamp(), timestamp()]
                 dd['data'].update({new_id: entry})
-                click.echo("Creating new task w/ id: %d -> %s" % (new_id, task))
-    
+                click.echo("Creating new task w/ id: %d -> %s" 
+                           % (new_id, task))
+
     write_data(config, dd)
     if ('repaint' in config and config['repaint']):
         display()

--- a/clikan_test.py
+++ b/clikan_test.py
@@ -50,9 +50,9 @@ def test_command_configure_existing():
         assert 'Config file exists' in result.output
 
 
-# New Tests
+## Single Argument Tests
 
-
+# Add Tests
 def test_command_a():
     runner = CliRunner()
     result = runner.invoke(clikan, ["a", "n_--task_test"])
@@ -117,9 +117,63 @@ def test_command_delete():
     assert 'No existing task with' in result.output
 
 
+## Multiple Argument Tests
+
+# Add Tests
+def test_command_a_multi():
+    runner = CliRunner()
+    result = runner.invoke(clikan, ["a", "n_--task_test_multi_1", "n_--task_test_multi_2", "n_--task_test_multi_3"])
+    assert result.exit_code == 0
+    assert 'n_--task_test' in result.output
+
+
+# Show Test
+def test_command_show_multi():
+    runner = CliRunner()
+    result = runner.invoke(show)
+    assert result.exit_code == 0
+    assert 'n_--task_test_multi_1' in result.output
+    assert 'n_--task_test_multi_2' in result.output
+    assert 'n_--task_test_multi_3' in result.output
+
+
+# Promote Tests
+def test_command_promote_multi():
+    runner = CliRunner()
+    result = runner.invoke(clikan, ['promote', '1', '2'])
+    assert result.exit_code == 0
+    assert 'Promoting task 1 to in-progress.' in result.output
+    assert 'Promoting task 2 to in-progress.' in result.output
+    result = runner.invoke(clikan, ['promote', '2', '3'])
+    assert result.exit_code == 0
+    assert 'Promoting task 2 to done.' in result.output
+    assert 'Promoting task 3 to in-progress.' in result.output
+
+
+# Delete Tests
+def test_command_delete_multi():
+    runner = CliRunner()
+    result = runner.invoke(clikan, ['delete', '1', '2'])
+    assert result.exit_code == 0
+    assert 'Removed task 1.' in result.output
+    assert 'Removed task 2.' in result.output
+    result = runner.invoke(clikan, ['delete', '1', '2'])
+    assert result.exit_code == 0
+    assert 'No existing task with that id: 1' in result.output
+    assert 'No existing task with that id: 2' in result.output
+
+
+# Show after delete Test
+def test_command_show_multi_after_delete():
+    runner = CliRunner()
+    result = runner.invoke(show)
+    assert result.exit_code == 0
+    assert 'n_--task_test_multi_1' not in result.output
+    assert 'n_--task_test_multi_2' not in result.output
+    assert 'n_--task_test_multi_3' in result.output
+
+
 # Repaint Tests
-
-
 def test_repaint_config_option():
     runner = CliRunner()
     version_file = open(os.path.join('./', 'VERSION'))
@@ -193,4 +247,4 @@ def test_no_taskname_config_option():
         assert 'clikan' in result.output
         result = runner.invoke(clikan, ["a", "This is a long task name, more than 40 characters (66 to be exact)"])
         assert result.exit_code == 0
-        assert 'Brevity counts.' in result.output
+        assert 'Brevity counts:' in result.output


### PR DESCRIPTION
Issue #56 for context: Operating on multiple tasks

Notes:
Replaced 4 `@click.argument('id')` with `@click.argument('id', nargs=-1)` to support multiple arguments. This converts arguments from strings to lists of strings so I added `for id in ids` loops. 
Moved `write_data` and `repaint` to the end of functions
Added a few `%s' % id` to error messages to remove ambiguity when operating on multiple tasks
Added tests for multi-argument test cases, tests pass on a blank .dat file but fail if re-ran without emptying .dat (due to task ids being incremental)